### PR TITLE
Replace deprecated optparse with argparse, per issue 683 [1]

### DIFF
--- a/gourmet/OptionParser.py
+++ b/gourmet/OptionParser.py
@@ -1,63 +1,39 @@
-import optparse
+import argparse
 import version
 try:
-    import optcomplete
-    has_optcomplete = True
+    import argcomplete
+    has_argcomplete = True
 except ImportError:
-    has_optcomplete = False
+    has_argcomplete = False
 
-parser = optparse.OptionParser(
-    version=version.version,
-    option_list=[
-    #optparse.make_option("-h","--help",action="help"),
-    optparse.make_option("--database-url",action='store',type='string',
-                         dest="db_url",help="Custom url for database of form driver://args/location",
-                         default=""),
-    optparse.make_option("--plugin-directory",action="store",type="string",
-                         dest="html_plugin_dir",help="Directory for webpage import filter plugins.",
-                         default="",
-                         ),
-    optparse.make_option("--use-threads",
-                         action="store_const",const=True,
-                         dest="threads",
-                         help="Enable threading support.",
-                         default=False),
-    optparse.make_option('--disable-threads',
-                         action='store_const',const=False,
-                         dest='threads',
-                         help='Disable threading support.'),
-    optparse.make_option("--gourmet-directory",
-                         action="store",
-                         dest="gourmetdir",
-                         help="Gourmet configuration directory",
-                         default=""),
-    optparse.make_option("--debug-threading-interval",
-                         action="store",
-                         type="float",
-                         dest='thread_debug_interval',
-                         help="Interval for threading debug calls",
-                         default=5.0),
-    optparse.make_option("--debug-threading",action="store_true",dest='thread_debug',
-                         help="Print debugging information about threading."),
-    optparse.make_option("--debug-file",action="store",type="string",dest="debug_file",
-                         help="Regular expression that matches filename(s) whose code we want to display debug messages from.",
-                         default=""),
-    optparse.make_option("-q",action='store_const',const=-1,
-                         dest='debug',
-                         help="Don't print gourmet error messages"),
-    optparse.make_option("--showtimes",action="store_true",dest="time",
-                         help="Print timestamps on debug statements."),
-    optparse.make_option("-v",action='count',
-                         help="Be verbose (extra v's will increase the verbosity level",
-                         dest='debug'),
-    optparse.make_option("--disable-psyco",
-                         dest="psyco",
-                         action="store_false",
-                         help="Do not use psyco if it is installed.",
-                         default=True),
-    ]
-    )
-if has_optcomplete:
-    optcomplete.autocomplete(parser)
+parser = argparse.ArgumentParser(prog='gourmet',description=version.description)
+parser.add_argument('--version',action='version',version=version.version)
+parser.add_argument('--database-url',action='store',dest='db_url',
+                     help='Custom url for database of form driver://args/location',default='')
+parser.add_argument('--plugin-directory',action='store',dest='html_plugin_dir',
+                     help='Directory for webpage import filter plugins.',default='')
+parser.add_argument('--use-threads',action='store_const',const=True,dest='threads',
+                     help='Enable threading support.',default=False)
+parser.add_argument('--disable-threads',action='store_const',const=False,dest='threads',
+                     help='Disable threading support.')
+parser.add_argument('--gourmet-directory',action='store',dest='gourmetdir',
+                     help='Gourmet configuration directory',default='')
+parser.add_argument('--debug-threading-interval',action='store',type=float,dest='thread_debug_interval',
+                     help='Interval for threading debug calls',default=5.0)
+parser.add_argument('--debug-threading',action='store_true',dest='thread_debug',
+                     help='Print debugging information about threading.')
+parser.add_argument('--debug-file',action='store',dest='debug_file',
+                     help='Regular expression that matches filename(s) containing code for which we want to display debug messages.',
+                     default='')
+parser.add_argument('--showtimes',action='store_true',dest='time',help='Print timestamps on debug statements.')
+parser.add_argument('--disable-psyco',dest='psyco',action='store_false',help='Do not use psyco if it is installed.',
+                     default=True)
 
-(options, args) = parser.parse_args()
+group = parser.add_mutually_exclusive_group()
+group.add_argument('-q',action='store_const',const=-1,dest='debug',help='Don\'t print gourmet error messages')
+group.add_argument('-v',action='count',dest='debug',help='Be verbose (extra v\'s will increase the verbosity level')
+
+if has_argcomplete:
+    argcomplete.autocomplete(parser)
+
+args = parser.parse_args()

--- a/gourmet/gdebug.py
+++ b/gourmet/gdebug.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python
-from OptionParser import options
+from OptionParser import args
 import time,traceback
 
-debug_level=options.debug
-debug_file=options.debug_file
-timestamp = options.time
+debug_level=args.debug
+debug_file=args.debug_file
+timestamp=args.time
 
 if debug_file:
     import re
@@ -33,7 +33,7 @@ def debug (message, level=10):
         else:
             finame = " ".join(stack)
             line = ""
-        if options.debug_file:
+        if args.debug_file:
             if debug_file.search(finame):
                 print "DEBUG: ",ts,"%s: %s"%(finame,line),message
         else:
@@ -61,7 +61,7 @@ class TimeAction:
             else:
                 finame = " ".join(stack)
                 line = ""
-            if not options.debug_file or debug_file.search(finame):
+            if not args.debug_file or debug_file.search(finame):
                 print "DEBUG: %s TOOK %s SECONDS"%(self.name,t)
                 if not timers.has_key(self.name): timers[self.name]=[t]
                 else: timers[self.name].append(t)

--- a/gourmet/gglobals.py
+++ b/gourmet/gglobals.py
@@ -30,12 +30,12 @@ makedirs = os.makedirs
 import os, os.path, gobject, re, gtk
 import tempfile
 from gdebug import debug
-from OptionParser import options
+from OptionParser import args
 
 tmpdir = tempfile.gettempdir()
 
-if options.gourmetdir:
-    gourmetdir = options.gourmetdir
+if args.gourmetdir:
+    gourmetdir = args.gourmetdir
     debug("User specified gourmetdir %s"%gourmetdir,0)
 else:
     if os.name =='nt':
@@ -106,7 +106,7 @@ if not os.access(gourmetdir,os.W_OK):
     
 debug('gourmetdir=%s'%gourmetdir,2)
 
-use_threads = options.threads
+use_threads = args.threads
 # Uncomment the below to test FauxThreads
 #use_threads = False
 
@@ -132,8 +132,8 @@ plugin_base = settings.plugin_base
 style_dir = os.path.join(base,'style')
 
 # GRAB PLUGIN DIR FOR HTML IMPORT
-if options.html_plugin_dir:
-    html_plugin_dir = options.html_plugin_dir
+if args.html_plugin_dir:
+    html_plugin_dir = args.html_plugin_dir
 else:
     html_plugin_dir = os.path.join(gourmetdir,'html_plugins')
     if not os.path.exists(html_plugin_dir):

--- a/gourmet/recipeManager.py
+++ b/gourmet/recipeManager.py
@@ -9,9 +9,9 @@ dbargs = {}
 
 if not dbargs.has_key('file'):
     dbargs['file']=os.path.join(gglobals.gourmetdir,'recipes.db')
-if OptionParser.options.db_url:
-    print 'We have a db_url and it is,',OptionParser.options.db_url
-    dbargs['custom_url'] = OptionParser.options.db_url
+if OptionParser.args.db_url:
+    print 'We have a db_url and it is,',OptionParser.args.db_url
+    dbargs['custom_url'] = OptionParser.args.db_url
     
 
 from backends.db import *


### PR DESCRIPTION
This patch replaces optparse with argparse.  This code will only work with
python 2.7 or greater, as argparse is new in 2.7.

1: https://github.com/thinkle/gourmet/issues/683
