### PR TITLE
Revert pointless variable rename

### DIFF
--- a/gourmet/OptionParser.py
+++ b/gourmet/OptionParser.py
@@ -36,4 +36,4 @@ group.add_argument('-v',action='count',dest='debug',help='Be verbose (extra v\'s
 if has_argcomplete:
     argcomplete.autocomplete(parser)
 
-args = parser.parse_args()
+options = parser.parse_args()

--- a/gourmet/__init__.py
+++ b/gourmet/__init__.py
@@ -10,19 +10,19 @@ import shopping
 import os.path
 import ImageExtras
 
-from OptionParser import args
+from OptionParser import options
 
 def thread_debug ():
     print 'THREADING DEBUG INFO: ',threading.enumerate()
-    t=threading.Timer(args.thread_debug_interval,thread_debug)
+    t=threading.Timer(options.thread_debug_interval,thread_debug)
     print '(starting timer: ',t,')'
     t.terminate = lambda *args: t.cancel()
     t.start()
 
-if args.thread_debug:
+if options.thread_debug:
     import threading
     thread_debug()
-elif args.psyco:
+elif options.psyco:
     try:
         import psyco
         psyco.full()

--- a/gourmet/gdebug.py
+++ b/gourmet/gdebug.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python
-from OptionParser import args
+from OptionParser import options
 import time,traceback
 
-debug_level=args.debug
-debug_file=args.debug_file
-timestamp=args.time
+debug_level=options.debug
+debug_file=options.debug_file
+timestamp = options.time
 
 if debug_file:
     import re
@@ -33,7 +33,7 @@ def debug (message, level=10):
         else:
             finame = " ".join(stack)
             line = ""
-        if args.debug_file:
+        if options.debug_file:
             if debug_file.search(finame):
                 print "DEBUG: ",ts,"%s: %s"%(finame,line),message
         else:
@@ -61,7 +61,7 @@ class TimeAction:
             else:
                 finame = " ".join(stack)
                 line = ""
-            if not args.debug_file or debug_file.search(finame):
+            if not options.debug_file or debug_file.search(finame):
                 print "DEBUG: %s TOOK %s SECONDS"%(self.name,t)
                 if not timers.has_key(self.name): timers[self.name]=[t]
                 else: timers[self.name].append(t)

--- a/gourmet/gglobals.py
+++ b/gourmet/gglobals.py
@@ -30,12 +30,12 @@ makedirs = os.makedirs
 import os, os.path, gobject, re, gtk
 import tempfile
 from gdebug import debug
-from OptionParser import args
+from OptionParser import options
 
 tmpdir = tempfile.gettempdir()
 
-if args.gourmetdir:
-    gourmetdir = args.gourmetdir
+if options.gourmetdir:
+    gourmetdir = options.gourmetdir
     debug("User specified gourmetdir %s"%gourmetdir,0)
 else:
     if os.name =='nt':
@@ -106,7 +106,7 @@ if not os.access(gourmetdir,os.W_OK):
     
 debug('gourmetdir=%s'%gourmetdir,2)
 
-use_threads = args.threads
+use_threads = options.threads
 # Uncomment the below to test FauxThreads
 #use_threads = False
 
@@ -132,8 +132,8 @@ plugin_base = settings.plugin_base
 style_dir = os.path.join(base,'style')
 
 # GRAB PLUGIN DIR FOR HTML IMPORT
-if args.html_plugin_dir:
-    html_plugin_dir = args.html_plugin_dir
+if options.html_plugin_dir:
+    html_plugin_dir = options.html_plugin_dir
 else:
     html_plugin_dir = os.path.join(gourmetdir,'html_plugins')
     if not os.path.exists(html_plugin_dir):

--- a/gourmet/recipeManager.py
+++ b/gourmet/recipeManager.py
@@ -9,9 +9,9 @@ dbargs = {}
 
 if not dbargs.has_key('file'):
     dbargs['file']=os.path.join(gglobals.gourmetdir,'recipes.db')
-if OptionParser.args.db_url:
-    print 'We have a db_url and it is,',OptionParser.args.db_url
-    dbargs['custom_url'] = OptionParser.args.db_url
+if OptionParser.options.db_url:
+    print 'We have a db_url and it is,',OptionParser.options.db_url
+    dbargs['custom_url'] = OptionParser.options.db_url
     
 
 from backends.db import *


### PR DESCRIPTION
I don't know what I was thinking when I renamed 'options' to 'args'; the change didn't improve anything.  Hence, I am reverting the name change.
