### PR TITLE
An importer for ica.se (Swedish storechain)

### DIFF
--- a/gourmet/plugins/import_export/website_import_plugins/__init__.py
+++ b/gourmet/plugins/import_export/website_import_plugins/__init__.py
@@ -1,7 +1,9 @@
 import about_dot_com_plugin
 import foodnetwork_plugin
 import allrecipes_plugin
+import ica_se_plugin
 plugins = [about_dot_com_plugin.AboutDotComPlugin,
            foodnetwork_plugin.FoodNetworkPlugin,
-           allrecipes_plugin.AllRecipesPlugin
+           allrecipes_plugin.AllRecipesPlugin,
+           ica_se_plugin.IcaSePlugin,
            ]

--- a/gourmet/plugins/import_export/website_import_plugins/ica_se_plugin.py
+++ b/gourmet/plugins/import_export/website_import_plugins/ica_se_plugin.py
@@ -1,0 +1,50 @@
+"""
+A plugin that tries to import recipes from the ica.se site
+"""
+from gourmet.plugin import PluginPlugin
+import re
+
+class Excluder(object):
+    def __init__(self, url):
+        self.url=url
+    def search(self, other_url):
+        return not (other_url.endswith(self.url))
+
+
+class IcaSePlugin (PluginPlugin):
+
+    target_pluggable = 'webimport_plugin'
+
+    def test_url (self, url, data):
+        "Is this url from ica.se"
+        if 'ica.se' in url:
+            return 5
+
+    def get_importer (self, webpage_importer):
+
+        class IcaSeParser (webpage_importer.WebParser):
+
+            imageexcluders = []
+
+            def preparse (self):
+                self.preparsed_elements = []
+                for tag in self.soup.findAll(itemprop=True):
+                    itemprop = tag.attrMap["itemprop"]
+                    if itemprop == "name":
+                        self.preparsed_elements.append((tag,'recipe'))
+                    elif itemprop == "totalTime":
+                        self.preparsed_elements.append((tag,'cooktime'))
+                    elif itemprop == "ingredients":
+                        self.preparsed_elements.append((tag,'ingredients'))
+                    elif itemprop == "recipeInstructions":
+                        self.preparsed_elements.append((tag,'instructions'))
+                    elif itemprop == "image":
+                        self.imageexcluders.append(Excluder(tag.attrMap["src"]))
+
+                if self.preparsed_elements:
+                    self.ignore_unparsed = True
+                else:
+                    webpage_importer.WebParser.preparse(self)
+
+        return IcaSeParser
+


### PR DESCRIPTION
A simple importer for web pages. 

The recepies are marked up using a microformat from http://schema.org/Recipe so the parser should be extendible to parse more sites. I will try to do this later, but for now I haven't  had the time to find more sites and try them.

There is a hack to set the image for the recipe based on parsing that should be removed later, but that needs an interface in WebParser to set the image.
