### PR TITLE
importing gettext in exportManager as it has localized strings

### DIFF
--- a/gourmet/exporters/exportManager.py
+++ b/gourmet/exporters/exportManager.py
@@ -3,6 +3,7 @@ from gourmet.plugin import ExporterPlugin
 import gourmet.gtk_extras.dialog_extras as de
 from gourmet.threadManager import get_thread_manager, get_thread_manager_gui
 from glib import get_user_special_dir, USER_DIRECTORY_DOCUMENTS
+from gettext import gettext as _
 import os.path
 
 EXTRA_PREFS_AUTOMATIC = -1


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/gourmet/+bug/1157969
