### PR TITLE
Remove "Application" from desktop entry

### DIFF
--- a/gourmet.desktop.in
+++ b/gourmet.desktop.in
@@ -4,6 +4,6 @@ _Comment=Organize recipes, create shopping lists, calculate nutritional informat
 Exec=gourmet
 Terminal=false
 Type=Application
-Categories=GNOME;Application;Utility;
+Categories=GNOME;Utility;
 StartupNotify=true
 Icon=gourmet


### PR DESCRIPTION
This makes the desktop-file-validate tool happy.

See http://standards.freedesktop.org/menu-spec/latest/ for valid categories.
