### PR TITLE
FIX: Create a shopping list even if one entry hasn't an amount

### DIFF
--- a/gourmet/convert.py
+++ b/gourmet/convert.py
@@ -889,20 +889,23 @@ def float_to_metric(n, approx=0.01):
         format_string = "%."+str(decimals_to_preserve)+"f"
     else:
         format_string = "%i"
-    if int(n) != n:
-        if (n - int(n) < approx) or ((n - int(n) + approx) > 1):
-            rounded = round(n)
-            if rounded == 0:
-                return float_to_metric(n,approx*.01)
-            return locale.format("%i",int(rounded),True)
-        else:
-            rounded = round(n,decimals_to_preserve)
-            if rounded == 0:
-                return float_to_metric(n,approx*.01)
-            return locale.format("%."+str(decimals_to_preserve)+"f",rounded,True) # format(formatstring, number, use_thousands_separator)
+    if n is not None:
+     if int(n) != n:
+         if (n - int(n) < approx) or ((n - int(n) + approx) > 1):
+             rounded = round(n)
+             if rounded == 0:
+                 return float_to_metric(n,approx*.01)
+             return locale.format("%i",int(rounded),True)
+         else:
+             rounded = round(n,decimals_to_preserve)
+             if rounded == 0:
+                 return float_to_metric(n,approx*.01)
+             return locale.format("%."+str(decimals_to_preserve)+"f",rounded,True) # format(formatstring, number, use_thousands_separator)
+     else:
+         return locale.format("%i",n,True)
     else:
-        return locale.format("%i",n,True)
-    
+         return ""
+
 def float_string (s):
     """Convert string to a float, assuming it is some sort of decimal number
 


### PR DESCRIPTION
The shopping list was not created, if an entry hasn't had an amount.
But this is quite normal e.g. for salt.
The error was that int() couldn't handle a None value.

This is not the best solution for this problem, but I don't know the code and python well enough to do it better.
