### PR TITLE
Fixed crash in MCB importer

### DIFF
--- a/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py
+++ b/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py
@@ -26,6 +26,8 @@ class MCBPlugin (ImporterPlugin):
         tempdir = tempfile.mkdtemp('mcb_zip')
         for name in zf.namelist():
             (dirname, filename) = os.path.split(name)
+            if not filename:
+                continue
             fulldirpath = os.path.join(tempdir,dirname)
             #Create the images dir if not exists yet
             if not os.path.exists(fulldirpath):


### PR DESCRIPTION
I tried to import a MCB export from 'Das kleine Rezeptbuch' (http://www.wboeck.de/rezeptbuch.htm) and got this crash:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/gourmet/GourmetRecipeManager.py", line 725, in do_import
    self.importManager.offer_import(self.window)
  File "/usr/lib/python2.7/site-packages/gourmet/importers/importManager.py", line 117, in offer_import
    self.import_filenames(filenames)
  File "/usr/lib/python2.7/site-packages/gourmet/importers/importManager.py", line 152, in import_filenames
    self.do_import(importer_plugin,'get_importer',fn)
  File "/usr/lib/python2.7/site-packages/gourmet/importers/importManager.py", line 161, in do_import
    importer = getattr(importer_plugin,method)(*method_args)
  File "/usr/lib/python2.7/site-packages/gourmet/plugins/import_export/mycookbook_plugin/mycookbook_importer_plugin.py", line 33, in get_importer
    outfile = open(os.path.join(tempdir, name), 'wb')
IOError: [Errno 21] Is a directory: '/tmp/tmpuq8H7Amcb_zip/Images/'
```

The content of the MCB files looks like this:

```
Archive:  Backen.mcb
    testing: Backen.xml               OK
    testing: Images/                  OK
    testing: Images/Fleckerlkuchen.jpg   OK
    testing: Images/Gewuerzplaetzchen.jpg   OK
    testing: Images/Pinguine.jpg      OK
```

The crash occurred because the MCB importer tried to handle the directory 'Images' as a file.
