### PR TITLE
HTML validation

### DIFF
--- a/gourmet/plugins/import_export/html_plugin/html_exporter.py
+++ b/gourmet/plugins/import_export/html_plugin/html_exporter.py
@@ -3,11 +3,11 @@ from gettext import gettext as _
 from gourmet import convert,gglobals
 from gourmet.exporters.exporter import ExporterMultirec, exporter_mult
 
-HTML_HEADER_START = """<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+HTML_HEADER_START = """<!DOCTYPE html>
 <html>
   <head>
   """
-HTML_HEADER_CLOSE = """<meta http-equiv="Content-Style-Stype" content="text/css">
+HTML_HEADER_CLOSE = """<meta http-equiv="Content-Style-Type" content="text/css">
      <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
      </head>"""
 
@@ -88,7 +88,7 @@ class html_exporter (exporter_mult):
         o.write(image)
         o.close()
         # we use urllib here because os.path may fsck up slashes for urls.
-        self.out.write('<img src="%s" itemprop="image">'%self.make_relative_link("%s%s.jpg"%(self.imagedir,
+        self.out.write('<img src="%s" itemprop="image" alt="">'%self.make_relative_link("%s%s.jpg"%(self.imagedir,
                                                                             self.imgcount)
                                                                 )
                        )


### PR DESCRIPTION
- microdata (itemscope, itemprop, etc) are not valid in html4, but they are in html5 ==> changed doctype (Issue #31)
- there was a typo on "Content-Style-Stype" ==> changed to "Content-Style-Type" (even though I'm not sure we need meta http-equiv anymore)
- the "alt" attribute on images is mandatory ==> added the attribute, although it's still empty (this is still valid): I don't know how to grab the title of the recipe, for now