### PR TITLE
Monkey-patch Pillow 3 to restore compatibility with PIL.

### DIFF
--- a/gourmet/gtk_extras/ratingWidget.py
+++ b/gourmet/gtk_extras/ratingWidget.py
@@ -10,6 +10,8 @@ try:
 except ImportError:
     import Image
 
+from gourmet.util import pillow3_compat
+
 PLUS_ONE_KEYS = ['plus',
                  'greater',
                  #'Up',
@@ -124,6 +126,7 @@ class StarGenerator:
                  self.height))
         return img
 
+    @pillow3_compat.patch_function
     def get_pixbuf_from_image (self, image, make_white_opaque=True):
 
         """Get a pixbuf from a PIL Image.

--- a/gourmet/plugins/browse_recipes/icon_helpers.py
+++ b/gourmet/plugins/browse_recipes/icon_helpers.py
@@ -4,6 +4,9 @@ try:
     from PIL import Image, ImageDraw
 except ImportError:
     import Image, ImageDraw
+
+from gourmet.util import pillow3_compat
+
 from gourmet.ImageExtras import get_pixbuf_from_jpg
 from gourmet.gtk_extras.ratingWidget import star_generator
 
@@ -27,6 +30,7 @@ def scale_pb (pb, do_grow=True):
         target_w = int(target * (float(w)/h))
     return pb.scale_simple(target_w,target_h,gtk.gdk.INTERP_BILINEAR)
 
+@pillow3_compat.patch_function
 def get_pixbuf_from_image (image):
 
     """Get a pixbuf from a PIL Image.

--- a/gourmet/util/pillow3_compat.py
+++ b/gourmet/util/pillow3_compat.py
@@ -1,0 +1,47 @@
+"""Make Pillow 3 backward compatible with PIL again.
+
+Pillow 3.0.0 removes, among others, Image.tostring().
+This module provides a context manager, patch(), and a decorator,
+patch_function(), to patch it back in.
+
+"""
+
+from contextlib import contextmanager
+from functools import wraps
+
+try:
+    from PIL import Image
+except ImportError:
+    import Image
+
+
+__all__ = ['patch', 'patch_function']
+
+
+@contextmanager
+def patch():
+    """Make Pillow 3 backward compatible in the with-block."""
+    old_tostring = Image.Image.tostring
+
+    def patched_tostring(self, *args, **kwargs):
+        try:
+            result = old_tostring(self, *args, **kwargs)
+        except Exception:
+            result = self.tobytes(*args, **kwargs)
+        return result
+
+    Image.Image.tostring = patched_tostring
+
+    try:
+        yield
+    finally:
+        Image.Image.tostring = old_tostring
+
+def patch_function(fn):
+    """Make Pillow 3 backward compatible in the decorated function."""
+    @wraps(fn)
+    def patched_fn(*args, **kwargs):
+        with patch():
+            f(*args, **kwargs)
+
+    return patched_fn


### PR DESCRIPTION
Pillow 3.0.0 replaces a few methods that were previously deprecated with
stubs that simply raise an exception. Since gourmet uses one of these
methods, Image.tostring(), and because PIL does not support the intended
replacement, Image.tobytes(), we'll have to patch support back in
(if we want to suport both PIL and Pillow).