### PR TITLE
Use Image.tobytes() instead of tostring()

### DIFF
--- a/gourmet/gtk_extras/ratingWidget.py
+++ b/gourmet/gtk_extras/ratingWidget.py
@@ -135,7 +135,7 @@ class StarGenerator:
         if is_rgba: rowstride = 4
         else: rowstride = 3
         pb=gtk.gdk.pixbuf_new_from_data(
-            image.tostring(),
+            image.tobytes(),
             gtk.gdk.COLORSPACE_RGB,
             is_rgba,
             8,

--- a/gourmet/plugins/browse_recipes/icon_helpers.py
+++ b/gourmet/plugins/browse_recipes/icon_helpers.py
@@ -38,7 +38,7 @@ def get_pixbuf_from_image (image):
     if is_rgba: rowstride = 4
     else: rowstride = 3
     pb=gtk.gdk.pixbuf_new_from_data(
-        image.tostring(),
+        image.tobytes(),
         gtk.gdk.COLORSPACE_RGB,
         is_rgba,
         8,


### PR DESCRIPTION
tostring() was deprecated (in Pillow at least) in version 2.0.  See https://github.com/python-pillow/Pillow/commit/baa5143394708704328dcd46b0387f36a276a762