### PR TITLE
Add util subpackage to installation in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -284,6 +284,7 @@ result = setup(
                 'gourmet.importers',
                 'gourmet.exporters',
                 'gourmet.plugins',
+                'gourmet.util',
                 ] + plugins,
     package_data = {'gourmet': ['plugins/*/*.ui', 'plugins/*/images/*.png','plugins/*/*/images/*.png']},
     cmdclass={'build' : build,


### PR DESCRIPTION
Installing from source and running gourmet from the command line caused
an error in the imports for gglobals.py.  Specifically, 'from util
import windows' threw an exception because the util package was not
installed.  This commit adds 'gourmet.util' to the packages list of the
setup() function in setup.py, which installs the corresponding sub-
package.

Fixes #798