### PR TITLE
Fix notification message when import cancelled

### DIFF
--- a/gourmet/GourmetRecipeManager.py
+++ b/gourmet/GourmetRecipeManager.py
@@ -1262,7 +1262,9 @@ class RecGui (RecIndex, GourmetApplication, ImporterExporter, StuffThatShouldBeP
             tm = get_thread_manager()
             tmg = get_thread_manager_gui()
             tm.add_thread(deleterThread)
-            tmg.register_thread_with_dialog(_('Delete Recipes'),_('Recipes deleted'),deleterThread)
+            tmg.register_thread_with_dialog(_('Delete Recipes'), deleterThread)
+            deleterThread.connect('completed', tmg.notification_thread_done,
+                    _('Recipes deleted'))
             tmg.show()
         else:
             return True

--- a/gourmet/exporters/exportManager.py
+++ b/gourmet/exporters/exportManager.py
@@ -155,8 +155,9 @@ class ExportManager (plugin_loader.Pluggable):
             if setup_gui:
                 tmg = get_thread_manager_gui()
                 tmg.register_thread_with_dialog(_('Export')+' ('+myexp.label+')',
-                                                _('Recipes successfully exported to <a href="file:///%s">%s</a>')%(fn,fn),
                                                 exporterInstance)
+                exporterInstance.connect('completed', tmg.notification_thread_done,
+                    _('Recipes successfully exported to <a href="file:///%s">%s</a>')%(fn,fn))
                 tmg.show()
             print 'Return exporter instance'
             return exporterInstance        

--- a/gourmet/importers/importManager.py
+++ b/gourmet/importers/importManager.py
@@ -159,6 +159,7 @@ class ImportManager (plugin_loader.Pluggable):
         '''
         try:
             importer = getattr(importer_plugin,method)(*method_args)
+            self.setup_notification_message(importer)
         except ImportFileList, ifl:
             # recurse with new filelist...
             return self.import_filenames(ifl.filelist)
@@ -174,7 +175,11 @@ class ImportManager (plugin_loader.Pluggable):
                 self.setup_thread(importer, label)
             print 'do_importer returns importer:',importer
             return importer
-                
+
+    def setup_notification_message(self, importer):
+        tmg = get_thread_manager_gui()
+        importer.connect('completed',tmg.importer_thread_done)
+
     @plugin_loader.pluggable_method
     def follow_up (self, threadmanager, importer):
         if hasattr(importer,'post_run'):
@@ -187,9 +192,7 @@ class ImportManager (plugin_loader.Pluggable):
         tm.add_thread(importer)
         tmg = get_thread_manager_gui()
         tmg.register_thread_with_dialog(label,
-                                        _('Recipes successfully imported'),
                                         importer)
-        tmg.show()
         if connect_follow_up:
             importer.connect('completed',
                              self.follow_up,

--- a/gourmet/threadManager.py
+++ b/gourmet/threadManager.py
@@ -244,8 +244,36 @@ class ThreadManagerGui:
     def response (self, dialog, response):
         if response==gtk.RESPONSE_CLOSE:
             self.close()
-        
-    def register_thread_with_dialog (self, description, done_msg, thread):
+
+    def importer_thread_done(self, thread):
+        # The following logic allows different messages to be displayed
+        # depending on if a recipe was actually imported or if the user
+        # cancelled the request.
+        if (len(thread.added_recs) >= 2):
+            done_message = _("Recipes successfully imported")
+        elif (len(thread.added_recs) == 1):
+            done_message = _("Recipe successfully imported")
+        elif (len(thread.added_recs) == 0):
+            done_message = _("Import Unsuccessful")
+        self.notification_thread_done(thread, done_message)
+
+    def notification_thread_done(self, thread, message):
+        infobox = gtk.InfoBar()
+        infobox.set_message_type(gtk.MESSAGE_INFO)
+        infobox.add_button(gtk.STOCK_DISCARD, gtk.RESPONSE_CLOSE)
+        infobox.connect('response', lambda ib, response_id: ib.hide())
+        infobox.show_all()
+        self.messagebox.pack_start(infobox)
+
+        from gourmet.gglobals import launch_url
+        l = gtk.Label()
+        l.set_markup(message)
+        l.connect('activate-link',lambda lbl, uri: launch_url(uri))
+        l.show()
+        infobox.get_content_area().add(l)
+        self.messagebox.show()
+
+    def register_thread_with_dialog (self, description, thread):
         threadbox = gtk.InfoBar()
         threadbox.set_message_type(gtk.MESSAGE_INFO)
         pb = gtk.ProgressBar()
@@ -261,9 +289,7 @@ class ThreadManagerGui:
         threadbox.get_content_area().add(vbox)
         threadbox.show_all()
         self.messagebox.pack_start(threadbox)
-
-        # This is a somewhat dirty hack.
-        threadbox.done_msg = done_msg
+        self.messagebox.show()
 
         #for b in threadbox.buttons: b.show()
         thread.connect('completed',self.thread_done,threadbox)
@@ -298,13 +324,7 @@ class ThreadManagerGui:
         pb.set_percentage(1)
         for widget in threadbox.get_content_area().get_children()[0]:
             widget.hide()
-
-        from gourmet.gglobals import launch_url
-        l = gtk.Label()
-        l.set_markup(threadbox.done_msg)
-        l.connect('activate-link',lambda lbl, uri: launch_url(uri))
-        l.show()
-        threadbox.get_content_area().add(l)
+        threadbox.hide()
 
     def progress_update (self, thread, perc, txt, pb):
         if perc >= 0.0:

--- a/gourmet/threadManager.py
+++ b/gourmet/threadManager.py
@@ -26,6 +26,7 @@
 #
 #
 from gettext import gettext as _
+from gettext import ngettext
 import threading, gtk, pango, gobject, time
 gobject.threads_init()
 
@@ -249,10 +250,10 @@ class ThreadManagerGui:
         # The following logic allows different messages to be displayed
         # depending on if a recipe was actually imported or if the user
         # cancelled the request.
-        if (len(thread.added_recs) >= 2):
-            done_message = _("Recipes successfully imported")
-        elif (len(thread.added_recs) == 1):
-            done_message = _("Recipe successfully imported")
+        if (len(thread.added_recs) > 0):
+            done_message = ngettext("Recipe successfully imported",
+                                    "Recipes successfully imported",
+                                    len(thread.added_recs))
         elif (len(thread.added_recs) == 0):
             done_message = _("Import Unsuccessful")
         self.notification_thread_done(thread, done_message)


### PR DESCRIPTION
When a user begins importing a website and cancels the import in the
interactive importer window the message "Recipe successfully imported"
is displayed.  This is untrue; the message should tell the user that
nothing was imported.  This pull request changes the displayed message
to "Import Unsuccessful" when an import is cancelled.

The behavior noted above is caused by a callback function, thread_done
in the threadManager.py module, assuming the import is successful.
When a user closes the interactive importer window this method hides
the previous "Downloading ..." message and updates it with "Recipe
successfully imported."  To avoid this assumption the thread_done
method is now only responsible for hiding the previous message.  A new
method, importer_thread_done, handles determining if 0, 1 or more
recipes were added and displays an appropriate message.  Making this a
separate function allows the importer (e.g. FoodNetworkParser) to be
connected and passed to the callback. The importer contains information 
on how many recipes are to be added, which is not present in the
previously used importManager object.

Note:  The export and deletion code was also changed to call a new 
notification display function, but no behavior was modified.

Fixes #832