### PR TITLE
Fix error thrown when disabling nutrition plugin

### DIFF
--- a/gourmet/plugin_loader.py
+++ b/gourmet/plugin_loader.py
@@ -366,7 +366,7 @@ class Pluggable:
     def remove_hook (self, type, name, hook):
         if type==PRE: hookdic = self.pre_hooks
         else: hookdic = self.post_hooks
-        del hookdic[name]
+        hookdic.pop(name, None)
 
     def get_plugin_by_module (self, module):
         for p in self.plugins:


### PR DESCRIPTION
The DatabasePlugin has two paths during activation and the path taken
is determined by if the main database has already been created or not.
If the database has not been created then a post hook is added allowin
the nutrition plugin to create tables after the database itself has
been initialized.  If the database has already been created the plugin
dives right into making the necessary tables and does not add a post
hook. The plugin disabling code assumes the post hook has been created
and attempts to delete it, so a KeyError occurs when it is not present

The current patch changes a dictionary delete call to a dict.pop()
call, so the key is removed if it is present and no error is thrown if
it is not.

Fixes #841