### PR TITLE
Allow week and month as unit of time

### DIFF
--- a/gourmet/convert.py
+++ b/gourmet/convert.py
@@ -65,6 +65,8 @@ class Converter:
                   # hrs = abbreviation for hours
                   ('hours',[_('hrs.'),'hrs','hr','h'] + [ngettext('hour','hours',n) for n in range(5)]),
                   ('days',[ngettext('day','days',n) for n in range(5)]),
+                  ('weeks',[ngettext('week','weeks',n) for n in range(5)]),
+                  ('months',[ngettext('month','months',n) for n in range(5)]),
                   ('years',[ngettext('year','years',n) for n in range(5)]),
                   #('decades',[ngettext('decade','decades',n) for n in range(5)]),
                   #('centuries',[ngettext('century','centuries',n) for n in range(5)]),


### PR DESCRIPTION
Currently, when a user inputs a preparation or cooking time in units
of weeks or months they are told the input is invalid.  This patch
adds week and month values to the Converter class so an error does not
occur.

Fixes #50