### PR TITLE
Allow import to proceed when ValueError occurs

### DIFF
--- a/gourmet/plugins/import_export/web_import_plugin/webpage_importer.py
+++ b/gourmet/plugins/import_export/web_import_plugin/webpage_importer.py
@@ -153,7 +153,10 @@ class WebParser (InteractiveImporter):
         for char,tup in BeautifulSoup.UnicodeDammit.MS_CHARS.items():
             char = char.decode('iso-8859-1').encode('utf-8')
             if to_add.find(char) >= 0:
-                to_add = to_add.replace(char,unichr(long(tup[1],16)))
+                try:
+                    to_add = to_add.replace(char,unichr(long(tup[1],16)))
+                except ValueError:
+                    print("ValueError caught in add_buffer_to_parsed")
         self.parsed.append((to_add,self.last_label))
 
     def format_tag_whitespace (self, tag):


### PR DESCRIPTION
The problem is detailed in issue #320.  When importing from
http://theurbanposer.com/perfect-dairy-free-almond-flour/ Gourmet
tries to call long(\'\'\n', 16) and this causes a ValueError.  The
only solution that worked for me is to wrap the call in a try/except
block.  This way the interactive importer pops up and the user is
allowed to set the markup as usual.

There were a couple differences I noticed when comparing a recipe imported
from the above site vs. epicurious.  The first is that the specific
section of add_buffer_to_parsed which causes the exception is not ran
in the epicurious recipe import.  The second is self.preparsed_elements
contains \n characters in the (html, 'label') tuples when importing
through theurbanposer.  These newline characters are not present in
recipes imported through epicurious (and I imagine the other specific
importers).  I'm not sure if either of these observations matter or if
they were specific to the recipes I tried to import.

Another difference was seen in the structure of the data in
self.preparsed_elements. In an import from epicurious, when printing
the contents of the first element of a tuple, so calling
self.preparsed_elements[any_#][0].contents, the result was a list of
length one with a NavigableString contained within it.  However, when
this was done during the problematic import, sometimes a list of
length 3 or 5 was returned with separate NavigableString or Tag values.
Again, I'm not sure if this is a significant difference but I haven't
seen that before.
