### PR TITLE
Fix german translation: Original has no within translation.

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -393,11 +393,11 @@ msgstr "Bewertung"
 
 #: ../ui/recCardDescriptionEditor.ui.h:17 ../gourmet/gglobals.py:89
 msgid "Yield"
-msgstr "E_rtrag"
+msgstr "Ertrag"
 
 #: ../ui/recCardDescriptionEditor.ui.h:18 ../gourmet/gglobals.py:90
 msgid "Yield Unit"
-msgstr "Einhe_it des Ertrags"
+msgstr "Einheit des Ertrags"
 
 #: ../ui/recCardDisplay.ui.h:1
 msgid "_Shop"


### PR DESCRIPTION
We shall never add an additional if there was no one in the original,
because this will affect also labels or description for e.g. during export
to epub. Looks rather ugly then.