### PR TITLE
Substitute SQL parameters prior to exeuction to support both sqlite3 and pymysql.

### DIFF
--- a/gourmet/exporters/exporter.py
+++ b/gourmet/exporters/exporter.py
@@ -523,7 +523,7 @@ class ExporterMultirec (SuspendableThread, Pluggable):
     def append_referenced_recipes (self):
         for r in self.recipes[:]:
             reffed = self.rd.db.execute(
-                'select * from ingredients where recipe_id=? and refid is not null',r.id
+                'select * from ingredients where recipe_id=%s and refid is not null' % r.id
                 )
             for ref in reffed:
                 rec = self.rd.get_rec(ref.refid)


### PR DESCRIPTION
This fixes https://github.com/thinkle/gourmet/issues/804