### PR TITLE
Fixed broken source tree run time paths (ticket #867)

### DIFF
--- a/bin/gourmet
+++ b/bin/gourmet
@@ -8,7 +8,7 @@ import sys
 
 # The following line is modified at installation time by setup.py so it
 # points to the actual modules installation path.
-lib_dir = '../..'
+lib_dir = '.'
 
 if lib_dir not in sys.path:
     sys.path.insert(0, lib_dir)

--- a/gourmet/gglobals.py
+++ b/gourmet/gglobals.py
@@ -51,7 +51,7 @@ use_threads = args.threads
 # note: this stuff must be kept in sync with changes in setup.py
 import settings
 uibase = os.path.join(settings.ui_base)
-lib_dir = os.path.join(settings.lib_dir,'gourmet')
+lib_dir = os.path.join(settings.lib_dir)
 
 # To have strings from .ui files (gtk.Builder) translated on all platforms,
 # we need the following module to enable localization on all platforms.

--- a/gourmet/settings.py
+++ b/gourmet/settings.py
@@ -4,17 +4,17 @@ import sys
 # The following lines are modified at installation time by setup.py so they
 # point to the actual data files installation paths.
 
-lib_dir = os.path.join(os.path.dirname(__file__),'../gourmet')
-base_dir = os.path.join(os.path.dirname(__file__),'..')
-data_dir = os.path.join(base_dir, "data")
+base_dir = os.path.join(os.path.dirname(__file__), '..')
+lib_dir = os.path.join(base_dir, 'gourmet')
+data_dir = os.path.join(base_dir, 'data')
 ui_base = os.path.join(base_dir, 'ui')
-doc_base = os.path.join(base_dir, "gourmet")
-locale_base = os.path.join(base_dir, "build", "mo")
-plugin_base = os.path.join(base_dir, "build", "share", "gourmet")
+doc_base = os.path.join(base_dir)
+locale_base = os.path.join(base_dir, 'build', 'mo')
+plugin_base = os.path.join(base_dir, 'build', 'share', 'gourmet')
 
 # Apologies for the formatting -- something in the build process is
 # getting rid of indentations in this file which throws a syntax error
 # on install
-if getattr(sys, 'frozen', False): base_dir = os.path.dirname(sys.executable); data_dir = base_dir; ui_base = os.path.join(base_dir, 'ui'); doc_base = os.path.join(base_dir, 'doc');locale_base = os.path.join(base_dir, "locale"); plugin_base = os.path.join(base_dir)
+if getattr(sys, 'frozen', False): base_dir = os.path.dirname(sys.executable); data_dir = base_dir; ui_base = os.path.join(base_dir, 'ui'); doc_base = os.path.join(base_dir, 'doc'); locale_base = os.path.join(base_dir, 'locale'); plugin_base = os.path.join(base_dir)
 
-icon_base = os.path.join(data_dir, "icons")
+icon_base = os.path.join(data_dir, 'icons')


### PR DESCRIPTION
1. The head of master fails to launch from source tree bin/ directory
2. Plugin path has 1 too many 'gourmet/' in path
3. doc_dir path is broken

For additional information refer to my comment in ticket #867 
