### PR TITLE
Fix AppStream metadata validation

### DIFF
--- a/gourmet.appdata.xml.in
+++ b/gourmet.appdata.xml.in
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 Thomas Hinkle <Thomas_Hinkle@alumni.brown.edu> -->
-<application>
- <id type="desktop">gourmet.desktop</id>
+<component type="desktop-application">
+ <id>com.github.gourmet</id>
  <metadata_license>CC0-1.0</metadata_license>
  <project_license>GPL-2.0</project_license>
+ <name>Gourmet</name>
+ <summary>Organize recipes, create shopping lists, calculate nutritional information, and more</summary>
  <description>
   <_p>
    Gourmet Recipe Manager is a recipe-organizer that allows you to collect,
@@ -21,9 +23,15 @@
   </_p>
  </description>
  <screenshots>
-  <screenshot type="default">http://thinkle.github.io/gourmet/images/screenshots/SearchView.png</screenshot>
-  <screenshot>http://thinkle.github.io/gourmet/images/screenshots/CardView.png</screenshot>
+  <screenshot type="default">
+   <image>https://thinkle.github.io/gourmet/images/screenshots/SearchView.png</image>
+  </screenshot>
+  <screenshot>
+   <image>https://thinkle.github.io/gourmet/images/screenshots/CardView.png</image>
+  </screenshot>
  </screenshots>
- <url type="homepage">http://thinkle.github.io/gourmet/</url>
- <updatecontact>https://github.com/thinkle/gourmet/issues</updatecontact>
-</application>
+ <launchable type="desktop-id">gourmet.desktop</launchable>
+ <url type="homepage">https://thinkle.github.io/gourmet/</url>
+ <url type="bugtracker">https://github.com/thinkle/gourmet/issues</url>
+ <update_contact>Thomas_Hinkle@alumni.brown.edu</update_contact>
+</component>

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ desktop_files=[
 	("share/gourmet/plugins/import_export", glob.glob("gourmet/plugins/import_export/*.gourmet-plugin.in"))
 	]
 xml_files=[
-	("share/appdata", ("gourmet.appdata.xml.in",)),
+	("share/metainfo", ("gourmet.appdata.xml.in",)),
 	]
 
 [build_icons]


### PR DESCRIPTION
This updates the AppStream metadata to a newer version, and fixes all compatibility problems detected by `appstreamcli validate gourmet.appdata.xml`:
```
I - gourmet.appdata.xml.in:gourmet.desktop:27
    Consider using a secure (HTTPS) URL for 'http://thinkle.github.io/gourmet/'

E - gourmet.appdata.xml.in:gourmet.desktop:24
    The screenshot does not contain any images.

E - gourmet.appdata.xml.in:gourmet.desktop
    The component is missing a name (<name/> tag).

E - gourmet.appdata.xml.in:gourmet.desktop:25
    The screenshot does not contain any images.

E - gourmet.appdata.xml.in:gourmet.desktop
    The component is missing a summary (<summary/> tag).

I - gourmet.appdata.xml.in:gourmet.desktop:4
    The id tag for "gourmet.desktop" still contains a 'type' property, probably from 
    an old conversion.

W - gourmet.appdata.xml.in:gourmet.desktop:28
    Found invalid tag: 'updatecontact'. Non-standard tags must be prefixed with 
    "x-".

W - gourmet.appdata.xml.in:gourmet.desktop:4
    The component ID is not a reverse domain-name. Please update the ID and that of 
    the accompanying .desktop file to follow the latest version of the Desktop-Entry 
    and AppStream specifications and avoid future issues.
```

And don't use legacy path for metainfo file. Metainfo files should be installed into /usr/share/metainfo. See: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location