### PR TITLE
Fix: broken 'Export all recipes' (#929)

### DIFF
--- a/gourmet/plugins/import_export/epub_plugin/epub_exporter.py
+++ b/gourmet/plugins/import_export/epub_plugin/epub_exporter.py
@@ -287,7 +287,7 @@ class website_exporter (ExporterMultirec):
             self.exportargs['conv']=conv
         ExporterMultirec.__init__(self, rd, recipe_table, out,
                                   one_file=True,
-                                  open_files=False,
+                                  create_file=False,
                                   ext=self.ext,
                                   exporter=epub_exporter,
                                   exporter_kwargs=self.exportargs)


### PR DESCRIPTION
- Fix for issue #929 - Can't 'Export all recipes'.
- This feature appears to be broken by commits 438c9c8 and 37494d1 with the deletion of variable `multiFileOpenByMyself` in class ExporterMultirec in module gourmet/exporters/exporter.py. Commits a3cacb0 and 76b8214 introduced variables `oneFileOpenByMyself` and `multiFileOpenByMyself` and parameter `open_files`.
- Changes made:
-- Instantiated `self.outdir = out` in `class ExportMultirec` constructor method (`__init__`)
-- Reintroduced a variable to indicate if a directory for multi files needs to be created, i.e. `create_multi_file`
-- Renamed `oneFileOpenByMyself` to `create_one_file` to better describe what the variable represents
-- Renamed class ExportMultirec parameter `open_files` to `create_file` to better describe what the parameter does
- This fix affects `class ExporterMultirec` and it's parameters.
