### PR TITLE
Prevent AttributeError when getting plugin list from plugins that fai…

### DIFF
--- a/gourmet/plugin_loader.py
+++ b/gourmet/plugin_loader.py
@@ -276,7 +276,11 @@ class PluginSet:
         else: raise AttributeError
 
     def get_plugins (self):
-        return self.get_module().plugins
+        module = self.get_module()
+        if module is None:
+            # this plugin had loading errors
+            return []
+        return module.plugins
 
     def load_plugin_file_data (self,plugin_info_file):
         # This should really use GKeyFile but there are no python


### PR DESCRIPTION
…led to load.

Error without the patch:

```
$ bin/gourmet
args1 = Namespace(db_url='', debug=None, debug_file='', gourmetdir='', html_plugin_dir='', psyco=True, thread_debug=False, thread_debug_interval=5.0, threads=False, time=False)
No pyglet player
No gst player
No windows player
WARNING: Plugin module import failed
PATH: ['.', '/home/calvin/src/gourmet.git/bin', '/usr/lib/python2.7', '/usr/lib/python2.7/plat-x86_64-linux-gnu', '/usr/lib/python2.7/lib-tk', '/usr/lib/python2.7/lib-old', '/usr/lib/python2.7/lib-dynload', '/home/calvin/.local/lib/python2.7/site-packages', '/usr/local/lib/python2.7/dist-packages', '/usr/lib/python2.7/dist-packages', '/usr/lib/python2.7/dist-packages/PILcompat', '/usr/lib/python2.7/dist-packages/gtk-2.0', '/usr/lib/python2.7/dist-packages/wx-3.0-gtk2', './gourmet/../build/share/gourmet/plugins', './gourmet/../gourmet/plugins', './gourmet/../gourmet/plugins/import_export', './gourmet/../build/share/gourmet/plugins/import_export']
Traceback (most recent call last):
  File "./gourmet/plugin_loader.py", line 260, in get_module
    self._loaded = __import__(self.module)
  File "./gourmet/../gourmet/plugins/import_export/website_import_plugins/__init__.py", line 7, in <module>
    import cooksillustrated_plugin
  File "./gourmet/../gourmet/plugins/import_export/website_import_plugins/cooksillustrated_plugin.py", line 7, in <module>
    from selenium import webdriver
ImportError: No module named selenium
WARNING: Failed to load plugin website_import_plugins
ERROR:root:
Traceback (most recent call last):
  File "./gourmet/plugin_loader.py", line 94, in load_active_plugins
    self.active_plugins.extend(self.available_plugin_sets[p].plugins)
  File "./gourmet/plugin_loader.py", line 273, in __getattr__
    if attr == 'plugins': return self.get_plugins()
  File "./gourmet/plugin_loader.py", line 279, in get_plugins
    return self.get_module().plugins
AttributeError: 'NoneType' object has no attribute 'plugins'

```