### PR TITLE
Fix markup in german translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -3669,7 +3669,7 @@ msgstr "Die Dichtedaten sind erforderlich."
 
 #: ../gourmet/plugins/unit_converter/converter.ui.h:3
 msgid "<b>From</b>"
-msgstr "<b>Von</B>"
+msgstr "<b>Von</b>"
 
 #: ../gourmet/plugins/unit_converter/converter.ui.h:6
 msgid "1"


### PR DESCRIPTION
fixes german markup error:
/usr/lib/python2.7/dist-packages/gourmet/plugins/unit_converter/convertGui.py:23: GtkWarning: Failed to set text from markup due to error parsing markup: Fehler in Zeile 1, Zeichen 18: Element »B« wurde geschlossen, aber das derzeit offene Element ist »b«
