### PR TITLE
Handle https and other URLs

### DIFF
--- a/gourmet/plugins/import_export/html_plugin/html_exporter.py
+++ b/gourmet/plugins/import_export/html_plugin/html_exporter.py
@@ -118,8 +118,7 @@ class html_exporter (exporter_mult):
     def write_attr (self, label, text):
         attr = gglobals.NAME_TO_ATTR.get(label,label)
         if attr=='link':
-            webpage = text.strip('http://')
-            webpage = webpage.split('/')[0]
+            webpage = text.split('/')[2]
             self.out.write('<a href="%s">'%text +
                            _('Original Page from %s')%webpage +
                            '</a>\n')


### PR DESCRIPTION
Fixes https://github.com/thinkle/gourmet/issues/957

More proper way would be to parse URLs, though that could complicate Python 2/3 compatibility.