### PR TITLE
Fix: Allow gtkspellcheck as alternative to gtkspell

### DIFF
--- a/gourmet/plugins/spellcheck/reccard_spellcheck_plugin.py
+++ b/gourmet/plugins/spellcheck/reccard_spellcheck_plugin.py
@@ -1,4 +1,9 @@
-import gtk, gtkspell
+import gtk
+
+try:
+    import gtkspell
+except:
+    import gtkspellcheck
 
 from gourmet.plugin import RecEditorPlugin, UIPlugin
 
@@ -14,7 +19,10 @@ class SpellPlugin (RecEditorPlugin, UIPlugin):
         for module in self.pluggable.modules:
             tvs = harvest_textviews(module.main)
             for tv in tvs:
-                gtkspell.Spell(tv)
+                try:
+                    gtkspell.Spell(tv)
+                except:
+                    gtkspellcheck.spellcheck.SpellChecker(tv)
 
 def harvest_textviews (widget):
     if isinstance(widget,gtk.TextView):
@@ -27,6 +35,3 @@ def harvest_textviews (widget):
         elif hasattr(widget,'get_child'):
             tvs.extend(harvest_textviews(widget.get_child()))
         return tvs
-
-
-


### PR DESCRIPTION
As of Ubuntu 16.04, 'gtkspell' is deprecated and replaced with
'gtkspellcheck'.

This change modifies 'reccard_spellcheck_plugin.py' to import
'gtkspellcheck' if 'gtkspell' is not installed.

(cherry picked from commit 676ca7bbe157d0b7549188ad7ebf56f5ad7a2db5)

Fixes #860