### PR TITLE
Address #931 and similar issue when parsing times

### DIFF
--- a/gourmet/convert.py
+++ b/gourmet/convert.py
@@ -644,7 +644,8 @@ all_number_words.sort(
     lambda x,y: ((len(y)>len(x) and 1) or (len(x)>len(y) and -1) or 0)
     )
 
-NUMBER_WORD_REGEXP = '|'.join(all_number_words).replace(' ','\s+')
+#NUMBER_WORD_REGEXP = '|'.join(all_number_words).replace(' ','\s+')
+NUMBER_WORD_REGEXP = None
 FRACTION_WORD_REGEXP = '|'.join(filter(lambda n: NUMBER_WORDS[n]<1.0,
                                        all_number_words)
                                 ).replace(' ','\s+')


### PR DESCRIPTION
All_number_words is not working perfectly here.  The number words need
to go through localization and also need word boundaries, otherwise
they match other partial ingredients or time words in other languages.
E.g., "ten" match the tail of the German word for minutes (Minuten).

Disable broken parsing of number words for now.

Fixes #931.

Signed-off-by: Martin Pohlack <martinp@gmx.de>