### PR TITLE
Fix locale time entry handling

### DIFF
--- a/gourmet/gtk_extras/timeEntry.py
+++ b/gourmet/gtk_extras/timeEntry.py
@@ -47,7 +47,7 @@ class TimeEntry (validatingEntry.ValidatingEntry):
                 return None
             else:
                 partial_unit = words[-1]
-            for u in self.conv.unit_to_seconds.keys():
+            for u in _(self.conv.unit_to_seconds.keys()):
                 if u.lower().find(partial_unit.lower())==0:
                     return None
                     #self._hide_warning_slowly()


### PR DESCRIPTION
Unit detection was not considering localization.  Fix the simple issue
in find_errors_in_progress() by translating units to compare against.

I suspect this might address two issues (#781 and #834).

Fixes #781.
Fixes #834.

Signed-off-by: Martin Pohlack <martinp@gmx.de>